### PR TITLE
ツイート詳細機能の実装

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -862,7 +862,7 @@ div.contents.row div.content_post {
   margin: 20px 0;
   padding: 30px;
   position: relative;
-  height: 200px;
+  height: 150px;
   color: #fff;
   background-size: cover;
   background-position: center center;
@@ -1056,4 +1056,16 @@ footer p {
 
 .search-form .search-btn {
   width: 10%;
+}
+
+.tweet_title span {
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.tweet_text {
+  border: 1px solid black;
+  border-radius: 5px;
+  background-color: #f5f5f5;
+  padding: 20px;
 }

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,4 +1,5 @@
 class TweetsController < ApplicationController
+  before_action :set_tweet, only: [:edit, :show]
   
   def index
     @tweets = Tweet.all
@@ -18,7 +19,6 @@ class TweetsController < ApplicationController
   end
 
   def edit
-    @tweet = Tweet.find(params[:id])
   end
 
   def update
@@ -26,9 +26,16 @@ class TweetsController < ApplicationController
     tweet.update(tweet_params)
   end
 
+  def show
+  end
+
   private
+
   def tweet_params
     params.require(:tweet).permit(:name, :title, :image, :text)
   end
 
+  def set_tweet
+    @tweet = Tweet.find(params[:id])
+  end
 end

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -5,6 +5,9 @@
         <span><%= image_tag 'arrow_top.png' %></span>
         <ul class="more_list">
           <li>
+            <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
+          </li>
+          <li>
             <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
           </li>
           <li>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,0 +1,24 @@
+<div class="contents row">
+  <div class="tweet_title">
+    <span>【<%= @tweet.title %>】</span>
+  </div>
+  <div class="content_post" style="background-image: url(<%= @tweet.image %>);background-size: cover; height: 300px;">
+    <div class="more">
+      <span><%= image_tag 'arrow_top.png' %></span>
+      <ul class="more_list">
+        <li>
+          <%= link_to '編集', edit_tweet_path(@tweet.id), method: :get %>
+        </li>
+        <li>
+          <%= link_to '削除', tweet_path(@tweet.id), method: :delete %>
+        </li>
+      </ul>
+    </div>
+    <p><%#= @tweet.title %></p>
+    <span class="name"><%= @tweet.name %>
+    </span>
+  </div>
+  <div class="tweet_text">
+    <%= simple_format(@tweet.text) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: 'tweets#index'
-  resources :tweets, only: [:index, :new, :create, :destroy, :edit, :update]
+  resources :tweets
 end


### PR DESCRIPTION
#What
ツイート詳細機能の実装

#Why
・ツイート一覧に詳細ページへ遷移するボタンを設置。
・詳細ページの実装
・詳細ページのカスタム(ビューの表示を編集)