### PR TITLE
表示順の並び替えの実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -3,7 +3,7 @@ class TweetsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   
   def index
-    @tweets = Tweet.includes(:user)
+    @tweets = Tweet.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
           <li>
             <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
           </li>
-          <% if user_signed_in? && current_user.id == @tweet.user_id %>
+          <% if user_signed_in? && current_user.id == tweet.user_id %>
             <li>
               <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
             </li>


### PR DESCRIPTION
#What
表示順の並び替えの実装

#Why
・トップページの投稿表示を新しい投稿順から表示する実装を行った。
・マイページへの遷移がエラーになってしまうので、記述を正しいものに直した。