### PR TITLE
部分テンプレートの実装

### DIFF
--- a/app/views/tweets/_dictionary.html.erb
+++ b/app/views/tweets/_dictionary.html.erb
@@ -1,0 +1,24 @@
+<div class="content_post" style="background-image: url(<%= tweet.image %>);">
+      <div class="more">
+        <span><%= image_tag 'arrow_top.png' %></span>
+        <ul class="more_list">
+          <li>
+            <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
+          </li>
+          <% if user_signed_in? && current_user.id == tweet.user_id %>
+            <li>
+              <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
+            </li>
+            <li>
+              <%= link_to '削除', tweet_path(tweet.id), method: :delete %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+      <p><%= tweet.title %></p>
+      <span class="name">
+        <a href="/users/<%= tweet.user.id %>">
+          <span>投稿者</span><%= tweet.user.nickname %>
+        </a>
+      </span>
+    </div>

--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(model: tweet, local: true) do |form| %>
+  <%= form.text_field :title, placeholder: "Title" %>
+  <%= form.text_field :image, placeholder: "Image Url" %>
+  <%= form.text_area :text, placeholder: "text", rows: "10" %>
+  <%= form.submit "SEND" %>
+<% end %>

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -1,11 +1,6 @@
 <div class="contents row">
   <div class="container">
     <h3>編集する</h3>
-    <%= form_with(model: @tweet, local: true) do |form| %>
-      <%= form.text_field :title, placeholder: "Title" %>
-      <%= form.text_field :image, placeholder: "Image Url" %>
-      <%= form.text_area :text, placeholder: "text", rows: "10" %>
-      <%= form.submit "SEND" %>
-    <% end %>
+    <%= render partial: "form", locals: { tweet: @tweet } %>
   </div>
 </div>

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,28 +1,5 @@
 <div class="contents row">
   <% @tweets.each do |tweet| %>
-    <div class="content_post" style="background-image: url(<%= tweet.image %>);">
-      <div class="more">
-        <span><%= image_tag 'arrow_top.png' %></span>
-        <ul class="more_list">
-          <li>
-            <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
-          </li>
-          <% if user_signed_in? && current_user.id == tweet.user_id %>
-            <li>
-              <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
-            </li>
-            <li>
-              <%= link_to '削除', tweet_path(tweet.id), method: :delete %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-      <p><%= tweet.title %></p>
-      <span class="name">
-        <a href="/users/<%= tweet.user.id %>">
-          <span>投稿者</span><%= tweet.user.nickname %>
-        </a>
-      </span>
-    </div>
+    <%= render partial: "dictionary", locals: { tweet: tweet } %>
   <% end %>
 </div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,11 +1,6 @@
 <div class="contents row">
   <div class="container">
     <h3>投稿する</h3>
-    <%= form_with(model: @tweet, local: true) do |form| %>
-      <%= form.text_field :title, placeholder: "Title" %>
-      <%= form.text_field :image, placeholder: "Image Url" %>
-      <%= form.text_area :text, placeholder: "text", rows: "10" %>
-      <%= form.submit "SEND" %>
-    <% end %>
+    <%= render partial: "form", locals: { tweet: @tweet } %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,24 +1,6 @@
 <div class="contents row">
   <p><%= @nickname %>さんの投稿一覧</p>
   <% @tweets.each do |tweet| %>
-    <div class="content_post" style="background-image: url(<%= tweet.image %>);">
-      <div class="more">
-        <span><%= image_tag 'arrow_top.png' %></span>
-        <ul class="more_list">
-          <li>
-            <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
-          </li>
-          <% if user_signed_in? && current_user.id == tweet.user_id %>
-            <li>
-              <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
-            </li>
-            <li>
-              <%= link_to '削除', tweet_path(tweet.id), method: :delete %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-      <p><%= tweet.title %></p>
-    </div>
+    <%= render partial: "tweets/dictionary", locals: { tweet: tweet } %>
   <% end %>
 </div>


### PR DESCRIPTION
#What
部分テンプレートの実装

#Why
・コードが重複する記述を1つのファイルに、まとめてrenderを用いて、記述の可読性を上げる実装を行いました。
・ビューに写る表示は、記述変更前と同じ、そのままになっています。